### PR TITLE
FutureRestore GUI — v1.98.1

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,5 +1,5 @@
 public class Main {
-    static final String futureRestoreGUIVersion = "1.98";
+    static final String futureRestoreGUIVersion = "1.98.1";
     static final boolean futureRestoreGUIPrerelease = false;
     public static void main(String[] args) {
         MainMenu.main();

--- a/src/main/java/MainMenu.java
+++ b/src/main/java/MainMenu.java
@@ -973,19 +973,32 @@ public class MainMenu {
         for (Map<String, Object> artifact : artifacts) {
             String assetName = ((String) artifact.get("name"));
             // Look for our OS and release binary
-            if (assetName.toLowerCase().contains(operatingSystem)
-                    && assetName.toLowerCase().contains("release")) {
-                // If we're mac, match architecture as well
-                if (assetName.toLowerCase().contains("mac")) {
-                    if (assetName.toLowerCase().contains(architecture)) {
+            String lcAssetName = assetName.toLowerCase();
+            if (lcAssetName.contains(operatingSystem) && lcAssetName.contains("release")) {
+                // If we're Mac
+                if (lcAssetName.contains("mac")) {
+                    // If the asset has an architecture in it
+                    if (lcAssetName.contains("x86_64") || lcAssetName.contains("arm64")) {
+                        // Match it with ours
+                        if (lcAssetName.contains(architecture)) {
+                            linkNameMap.put("link", (String) artifact.get("archive_download_url"));
+                            linkNameMap.put("name", assetName);
+                            return linkNameMap;
+                        }
+                    }
+                    // Otherwise, don't worry about matching architecture
+                    else {
                         linkNameMap.put("link", (String) artifact.get("archive_download_url"));
                         linkNameMap.put("name", assetName);
+                        return linkNameMap;
                     }
-                } else {
+                }
+                // Not Mac
+                else {
                     linkNameMap.put("link", (String) artifact.get("archive_download_url"));
                     linkNameMap.put("name", assetName);
+                    return linkNameMap;
                 }
-                return linkNameMap;
             }
         }
 


### PR DESCRIPTION
### Bug fixes in v1.98.1:

- Fixed download FutureRestore beta not doing anything when macOS universal binaries are available.

### What's new in v1.98:

- Added the new `--custom-latest-buildid` and `--custom-latest-beta` arguments.
- Added `--no-restore` and `--serial` arguments.
- Redesigned tabbed pane (again)
  - The log window is now in the "Controls" tab
- Detect selected arguments not included in FutureRestore binary and parse the errors
- If a shell script is included in a FutureRestore download, prompt to run it
- The GUI knows if it's a prerelease and will prompt for prerelease updates
  - Release versions will continue to only get full release updates
- The "Current Task" text pane is now scrollable horizontally, in case the output is too long

### Bug fixes:

- Fixed argument boxes not appearing immediately after enabling the corresponding checkbox.